### PR TITLE
Log number of parameters of a model

### DIFF
--- a/examples/causal_language_modeling/mlflow_peft_lora_clm_accelerate_ds_zero3_offload.py
+++ b/examples/causal_language_modeling/mlflow_peft_lora_clm_accelerate_ds_zero3_offload.py
@@ -28,6 +28,14 @@ import time
 #     mlflow_uri = "http://127.0.0.1:5001"
 #     mlflow.set_tracking_uri(mlflow_uri)
 
+def get_num_parameters(model):
+  num_params = 0
+  for param in model.parameters():
+    num_params += param.numel()
+  # in million
+  num_params /= 10**6
+  return num_params
+
 def levenshtein_distance(str1, str2):
     # TC: O(N^2)
     # SC: O(N^2)
@@ -252,6 +260,10 @@ def main(args):
         is_ds_zero_3 = accelerator.state.deepspeed_plugin.zero_stage == 3
 
     mlflow.start_run()
+
+    num_params = get_num_parameters(model)
+    mlflow.log_param('num_params', num_params)
+
     start_time = time.time()
     for epoch in range(num_epochs):
         interval_start_time = time.time()

--- a/examples/conditional_generation/mlflow_peft_adalora_seq2seq.py
+++ b/examples/conditional_generation/mlflow_peft_adalora_seq2seq.py
@@ -10,6 +10,14 @@ from peft import AdaLoraConfig, PeftConfig, PeftModel, TaskType, get_peft_model
 import mlflow
 import time
 
+def get_num_parameters(model):
+  num_params = 0
+  for param in model.parameters():
+    num_params += param.numel()
+  # in million
+  num_params /= 10**6
+  return num_params
+
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -54,6 +62,8 @@ experiment_id = mlflow.create_experiment('conditional_generation-{}'.format(mode
 experiment = mlflow.get_experiment(experiment_id)
 mlflow_runner = mlflow.start_run(run_name=model_name_or_path, experiment_id=experiment.experiment_id)
 
+num_params = get_num_parameters(model)
+mlflow.log_param('num_params', num_params)
 
 # loading dataset
 dataset = load_dataset("financial_phrasebank", "sentences_allagree")

--- a/examples/conditional_generation/mlflow_peft_lora_seq2seq_accelerate_ds_zero3_offload.py
+++ b/examples/conditional_generation/mlflow_peft_lora_seq2seq_accelerate_ds_zero3_offload.py
@@ -54,6 +54,14 @@ def b2mb(x):
     return int(x / 2**20)
 
 
+def get_num_parameters(model):
+  num_params = 0
+  for param in model.parameters():
+    num_params += param.numel()
+  # in million
+  num_params /= 10**6
+  return num_params
+
 # This context manager is used to track the peak memory usage of the process
 class TorchTracemalloc:
     def __enter__(self):
@@ -193,6 +201,10 @@ def main(args):
 
 
     mlflow.start_run()
+
+    num_params = get_num_parameters(model)
+    mlflow.log_param('num_params', num_params)
+
     start_time = time.time()
     for epoch in range(num_epochs):
         with TorchTracemalloc() as tracemalloc:

--- a/examples/conditional_generation/mlflow_peft_lora_seq2seq_accelerate_fsdp.py
+++ b/examples/conditional_generation/mlflow_peft_lora_seq2seq_accelerate_fsdp.py
@@ -13,6 +13,14 @@ import mlflow
 import time
 
 
+def get_num_parameters(model):
+  num_params = 0
+  for param in model.parameters():
+    num_params += param.numel()
+  # in million
+  num_params /= 10**6
+  return num_params
+
 def main():
     accelerator = Accelerator()
     model_name_or_path = "t5-base"
@@ -62,6 +70,8 @@ def main():
     experiment_id = mlflow.create_experiment('conditional_generation-{}'.format(model_name_or_path))
     experiment = mlflow.get_experiment(experiment_id)
     mlflow_runner = mlflow.start_run(run_name=model_name_or_path, experiment_id=experiment.experiment_id)
+    num_params = get_num_parameters(model)
+    mlflow.log_param('num_params', num_params)
 
     with accelerator.main_process_first():
         processed_datasets = dataset.map(

--- a/examples/image_classification/mlflow_image_classification_peft_lora.py
+++ b/examples/image_classification/mlflow_image_classification_peft_lora.py
@@ -63,6 +63,14 @@ val_transforms = Compose([
     normalize,
 ])
 
+def get_num_parameters(model):
+  num_params = 0
+  for param in model.parameters():
+    num_params += param.numel()
+  # in million
+  num_params /= 10**6
+  return num_params
+
 # Preprocess functions for train and val datasets
 def preprocess_train(example_batch):
     example_batch["pixel_values"] = [train_transforms(image.convert("RGB")) for image in example_batch["image"]]
@@ -134,6 +142,9 @@ training_args = TrainingArguments(
 experiment_id = mlflow.create_experiment('image_classification-{}'.format(model_name))
 experiment = mlflow.get_experiment(experiment_id)
 mlflow_runner = mlflow.start_run(run_name=model_name, experiment_id=experiment.experiment_id)
+
+num_params = get_num_parameters(lora_model)
+mlflow.log_param('num_params', num_params)
 
 # Compute evaluation metrics
 metric = evaluate.load("accuracy")

--- a/examples/semantic_segmentation/mlflow_semantic_segmentation_peft_lora.py
+++ b/examples/semantic_segmentation/mlflow_semantic_segmentation_peft_lora.py
@@ -41,6 +41,13 @@ num_labels = len(id2label)
 image_processor = AutoImageProcessor.from_pretrained(args.checkpoint, reduce_labels=True)
 jitter = ColorJitter(brightness=0.25, contrast=0.25, saturation=0.25, hue=0.1)
 
+def get_num_parameters(model):
+  num_params = 0
+  for param in model.parameters():
+    num_params += param.numel()
+  # in million
+  num_params /= 10**6
+  return num_params
 
 def handle_grayscale_image(image):
     np_image = np.array(image)
@@ -138,6 +145,8 @@ model_name = args.checkpoint.split("/")[-1]
 experiment_id = mlflow.create_experiment('semantic_segmentation-{}'.format(model_name))
 experiment = mlflow.get_experiment(experiment_id)
 mlflow_runner = mlflow.start_run(run_name=model_name, experiment_id=experiment.experiment_id)
+num_params = get_num_parameters(model)
+mlflow.log_param('num_params', num_params)
 
 training_args = TrainingArguments(
     output_dir=args.output_dir,

--- a/examples/sequence_classification/mlflow_peft_no_lora_accelerate.py
+++ b/examples/sequence_classification/mlflow_peft_no_lora_accelerate.py
@@ -80,6 +80,14 @@ def parse_args():
     return args
 
 
+def get_num_parameters(model):
+  num_params = 0
+  for param in model.parameters():
+    num_params += param.numel()
+  # in million
+  num_params /= 10**6
+  return num_params
+
 def main():
     args = parse_args()
     ddp_scaler = DistributedDataParallelKwargs(find_unused_parameters=True)
@@ -176,6 +184,9 @@ def main():
             model, train_dataloader, eval_dataloader, optimizer, lr_scheduler
         )
     mlflow.start_run()
+    num_params = get_num_parameters(model)
+    mlflow.log_param('num_params', num_params)
+
     start_time = time.time()
     for epoch in range(args.num_train_epochs):
         model.train()


### PR DESCRIPTION
Background
We currently include the size information in the model name and use it to differentiate between model sizes. However, I think it's too hard to tell what size this model is with a size name like '-base', '-large', '-b0' etc.

Even, nowadays, the number of parameters, such as 7b, is used as a suffix to express the size of the model. This numbering tells us more information. How much GPU memory usage will be occupied when a model is loaded. It also makes it easier to compare model sizes between similar types of models, such as trasnformers models.

What this PR does
- calculate the number of parameters of a model and log using mlflow.log_param().