### PR TITLE
Delete deepspeed from requirements

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -10,7 +10,6 @@ Pillow==10.1.0
 torchvision==0.14.1
 huggingface_hub==0.18.0
 accelerate==0.24.0
-deepspeed==0.11.1
 mlflow==2.4.1
 psutil==5.9.4
 black==23.7.0


### PR DESCRIPTION
No need to install deepspeed since we do not have a relevant CUDA_HOME to cope with nvcc.