### PR TITLE
Update setuptools to 69.5.1

### DIFF
--- a/requirements.moreh.txt
+++ b/requirements.moreh.txt
@@ -10,7 +10,7 @@ Pillow>=10.1.0
 huggingface_hub==0.18.0
 accelerate==0.24.0
 sentencepiece==0.1.99
-setuptools==65.5.0
+setuptools==69.5.1
 mlflow
 psutil
 black


### PR DESCRIPTION
## Background
Our latest `moreh_driver` (version `24.8.3020`) on Nexus requires `setuptools` version `69.5.1`. However, our benchmarks are currently using `setuptools` version `65.5.0`, as specified in our `requirements.moreh.txt` file, which is causing compatibility issues.

## Contents
- Update `setuptools` to `69.5.1`.